### PR TITLE
Flip the order of _msg and _sent in zmq::frame

### DIFF
--- a/src/zmqpp/frame.hpp
+++ b/src/zmqpp/frame.hpp
@@ -54,9 +54,9 @@ public:
 	frame copy() const;
 
 private:
-	bool _sent;
 	zmq_msg_t _msg;
-
+	bool _sent;
+	
 	// Disable implicit copy support, code must request a copy to clone
 	frame(frame const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
 	frame& operator=(frame const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;


### PR DESCRIPTION
As stated in zmq.h, the zmq_msg_t structure must be aligned on the address boundary if sigbus violations are to be avoided on architectures enforcing the pointer alignment.